### PR TITLE
set max age to allow cookies to persist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "@babel/preset-env", {
         "targets": "> 0.25%, not dead",
-        useBuiltIns: "usage",
+        "useBuiltIns": "usage",
         "corejs": 2,
       }
     ],

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -43,7 +43,7 @@ app.use(
       saveUninitialized: true,
       store: new MongoStore({ mongooseConnection: mongoose.connection}),
       cookie: {
-        secure: true,
+        secure: process.env.PROD == 'true' ? true : false,
         maxAge: 365 * 24 * 60 * 60 * 1000
       }
     })

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -41,7 +41,11 @@ app.use(
       name: 'encoresesssionid',
       resave: true,
       saveUninitialized: true,
-      store: new MongoStore({ mongooseConnection: mongoose.connection})
+      store: new MongoStore({ mongooseConnection: mongoose.connection}),
+      cookie: {
+        secure: true,
+        maxAge: 365 * 24 * 60 * 60 * 1000
+      }
     })
 );
 


### PR DESCRIPTION
Fix to allow for cookies to persist beyond browser closing (this will keep them around for a year before expiring), slight correction on .babelrc file.